### PR TITLE
Update io-package.json

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -137,7 +137,7 @@
 			"common": {
 				"role": "",
 				"name": "Operationmode one of(auto, cool, heat, dry, fan_only)",
-				"type": "text",
+				"type": "string",
 				"read": true,
 				"write": true,
 				"def": "auto"
@@ -150,7 +150,7 @@
 			"common": {
 				"role": "",
 				"name": "Fan Speed one of(auto, low, mediumLow, medium, mediumHigh, high)",
-				"type": "text",
+				"type": "string",
 				"read": true,
 				"write": true,
 				"def": "auto"
@@ -163,7 +163,7 @@
 			"common": {
 				"role": "",
 				"name": "Air selection, one of(off, inside, outside, mode3)",
-				"type": "text",
+				"type": "string",
 				"read": true,
 				"write": true,
 				"def": "off"
@@ -215,7 +215,7 @@
 			"common": {
 				"role": "",
 				"name": "QuietMode (off, mode1, mode2, mode3)",
-				"type": "text",
+				"type": "string",
 				"read": true,
 				"write": true,
 				"def": "noset"


### PR DESCRIPTION
Set type "text" to "string":

gree_aircon.0	2021-05-25 20:41:14.099	warn	(22285) This object will not be created in future versions. Please report this to the developer.
gree_aircon.0	2021-05-25 20:41:14.098	warn	(22285) Object gree_aircon.0.quiet is invalid: obj.common.type has an invalid value (text) but has to be one of number, string, boolean, array, object, mixed, file, json
gree_aircon.0	2021-05-25 20:41:14.081	warn	(22285) This object will not be created in future versions. Please report this to the developer.
gree_aircon.0	2021-05-25 20:41:14.081	warn	(22285) Object gree_aircon.0.air is invalid: obj.common.type has an invalid value (text) but has to be one of number, string, boolean, array, object, mixed, file, json
gree_aircon.0	2021-05-25 20:41:14.074	warn	(22285) This object will not be created in future versions. Please report this to the developer.
gree_aircon.0	2021-05-25 20:41:14.074	warn	(22285) Object gree_aircon.0.fanSpeed is invalid: obj.common.type has an invalid value (text) but has to be one of number, string, boolean, array, object, mixed, file, json
gree_aircon.0	2021-05-25 20:41:14.067	warn	(22285) This object will not be created in future versions. Please report this to the developer.
gree_aircon.0	2021-05-25 20:41:14.066	warn	(22285) Object gree_aircon.0.mode is invalid: obj.common.type has an invalid value (text) but has to be one of number, string, boolean, array, object, mixed, file, json